### PR TITLE
docs: update README and CLAUDE.md for plugins/ restructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a Go-based skill generator that automatically transforms AEL (Adaptive Enforcement Lab) documentation into Claude Code skills. The project follows Clean/Hexagonal Architecture and uses release-please for automated releases.
 
-**CRITICAL**: The `skills/` directory contains auto-generated files. Never manually edit files in `skills/` - they are regenerated from source documentation at [adaptive-enforcement-lab.com](https://github.com/adaptive-enforcement-lab/adaptive-enforcement-lab-com).
+**CRITICAL**: The `plugins/` directory contains auto-generated files. Never manually edit files in `plugins/` - they are regenerated from source documentation at [adaptive-enforcement-lab.com](https://github.com/adaptive-enforcement-lab/adaptive-enforcement-lab-com).
 
 ## Build and Development Commands
 
@@ -19,14 +19,14 @@ cd skillgen && go build -o ../bin/skillgen ./cmd/skillgen && cd ..
 # Run the generator (requires AEL docs locally)
 ./bin/skillgen \
   --source ../adaptive-enforcement-lab-com/docs \
-  --output skills \
+  --output plugins \
   --plugin-metadata ./plugin-metadata.json \
   --release-manifest ./.release-please-manifest.json
 
 # Run with verbose logging
 ./bin/skillgen \
   --source ../adaptive-enforcement-lab-com/docs \
-  --output skills \
+  --output plugins \
   --plugin-metadata ./plugin-metadata.json \
   --release-manifest ./.release-please-manifest.json \
   --verbose
@@ -41,7 +41,7 @@ gofmt -w skillgen/
 ### Generator Options
 
 - `--source`: Path to AEL documentation source (required)
-- `--output`: Output path for generated skills (default: `./skills`)
+- `--output`: Output path for generated plugins (default: `./plugins`)
 - `--plugin-metadata`: Path to plugin metadata config (default: `./plugin-metadata.json`)
 - `--release-manifest`: Path to release-please manifest (default: `./.release-please-manifest.json`)
 - `--templates`: Path to template directory (default: `./templates`)
@@ -148,7 +148,7 @@ Templates live in `templates/` and use Go's text/template syntax:
 - Builds generator and runs skill generation with `--plugin-metadata` and `--release-manifest` flags
 - Generates all marketplace files automatically:
   - `.claude-plugin/marketplace.json`
-  - `skills/*/​.claude-plugin/plugin.json` for each collection
+  - `plugins/*/​.claude-plugin/plugin.json` for each collection
 - Creates idempotent PR with branch `chore/regenerate-skills`
 - PR is reused for subsequent runs (force push updates)
 
@@ -163,10 +163,10 @@ Templates live in `templates/` and use Go's text/template syntax:
 Release-please manages 6 independent components:
 - `skillgen` (Go binary) - main version
 - `marketplace` (.claude-plugin/) - marketplace metadata
-- `patterns` (skills/patterns/) - pattern skills collection
-- `enforcement` (skills/enforce/) - enforcement skills collection
-- `build` (skills/build/) - build skills collection
-- `secure` (skills/secure/) - secure skills collection
+- `patterns` (plugins/patterns/) - pattern skills collection
+- `enforce` (plugins/enforce/) - enforcement skills collection
+- `build` (plugins/build/) - build skills collection
+- `secure` (plugins/secure/) - secure skills collection
 
 Each uses separate-pull-requests for independent versioning.
 
@@ -219,9 +219,9 @@ Go 1.25+ with minimal external dependencies:
 
 ## Common Pitfalls
 
-1. **Editing skills/ directly** - These are auto-generated, edits will be overwritten
+1. **Editing plugins/ directly** - These are auto-generated, edits will be overwritten
 2. **Editing .claude-plugin/marketplace.json directly** - Auto-generated from plugin-metadata.json
-3. **Editing skills/*/​.claude-plugin/plugin.json directly** - Auto-generated from plugin-metadata.json
+3. **Editing plugins/*/​.claude-plugin/plugin.json directly** - Auto-generated from plugin-metadata.json
 4. **Forgetting --plugin-metadata and --release-manifest flags** - Required for marketplace generation
 5. **Forgetting --source flag** - Generator requires source docs path
 6. **Assuming specific section names** - Source docs vary, extractor uses fuzzy matching

--- a/README.md
+++ b/README.md
@@ -79,20 +79,32 @@ To auto-register this marketplace for your team, add to `.claude/settings.json` 
 .claude-plugin/
 └── marketplace.json              # Marketplace catalog
 
-skills/                           # Generated skills (DO NOT EDIT)
-├── .generated                    # Marker file
-├── patterns/                     # Pattern-based skills
-├── enforcement/                  # Enforcement automation skills
-└── build/                        # Build engineering skills
+plugins/                          # Generated plugins (DO NOT EDIT)
+├── patterns/
+│   ├── .claude-plugin/
+│   │   └── plugin.json          # Plugin metadata
+│   └── skills/                   # Pattern skills
+├── enforce/
+│   ├── .claude-plugin/
+│   │   └── plugin.json          # Plugin metadata
+│   └── skills/                   # Enforcement skills
+├── build/
+│   ├── .claude-plugin/
+│   │   └── plugin.json          # Plugin metadata
+│   └── skills/                   # Build skills
+└── secure/
+    ├── .claude-plugin/
+    │   └── plugin.json          # Plugin metadata
+    └── skills/                   # Security skills
 
-cmd/skillgen/                     # Main application
-internal/                         # Internal packages
-├── parser/                       # Content parsers
-├── extractor/                    # Component extractors
-├── generator/                    # Skill generators
-└── validator/                    # Validation logic
-
-templates/                        # Go templates
+skillgen/                         # Generator source
+├── cmd/skillgen/                 # Main application
+├── internal/
+│   ├── domain/                   # Core entities
+│   ├── ports/                    # Interfaces
+│   ├── adapters/                 # Implementations
+│   └── services/                 # Business logic
+└── templates/                    # Go templates
 
 .github/workflows/
 └── generate-skills.yml           # CI automation
@@ -102,13 +114,17 @@ templates/                        # Go templates
 
 ```bash
 # Build the generator
-go build -o bin/skillgen ./cmd/skillgen
+cd skillgen && go build -o ../bin/skillgen ./cmd/skillgen
 
-# Run generator
-./bin/skillgen --source ../adaptive-enforcement-lab-com/docs
+# Run generator (from repo root)
+./bin/skillgen \
+  --source ../adaptive-enforcement-lab-com/docs \
+  --output plugins \
+  --plugin-metadata ./plugin-metadata.json \
+  --release-manifest ./.release-please-manifest.json
 
 # Run tests
-go test ./...
+cd skillgen && go test ./...
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed development guidelines.


### PR DESCRIPTION
## Summary

Updates documentation to accurately reflect the directory restructure from `skills/` to `plugins/` completed in PR #44.

## Problem

README.md and CLAUDE.md still referenced the old `skills/` directory structure and outdated command examples, causing confusion for developers and contributors.

## Changes

### README.md
- **Repository Structure**: Updated diagram to show `plugins/{name}/skills/` hierarchy with plugin.json locations
- **Development Commands**: Changed examples to use `--output plugins`
- **Structure Clarity**: Added detailed breakdown showing skillgen/ subdirectory organization

### CLAUDE.md
- **Critical Warning**: Updated to reference `plugins/` directory
- **All Commands**: Updated generator examples to use `--output plugins`
- **Generator Options**: Changed default from `./skills` to `./plugins`
- **CI/CD Workflows**: Updated paths to `plugins/*/.claude-plugin/plugin.json`
- **Multi-Component Versioning**: Updated all component paths (e.g., `plugins/patterns/`)
- **Common Pitfalls**: Changed warnings about editing `skills/` to `plugins/`
- **Comprehensive**: All 8 references to `skills/` changed to `plugins/`

## Impact

- Developers will now see accurate documentation matching actual repository structure
- Commands can be copy-pasted without modification
- Reduces confusion about where generated files are located
- Aligns with the breaking change in PR #44

## Test Plan

- [x] Verified all command examples are correct
- [x] Checked repository structure diagram matches actual layout
- [x] Confirmed no remaining `skills/` references in changed files
- [x] All paths reference current directory structure

## Related

Follow-up to #44 (directory restructure)
Complements #51 (plugin.json version fix)