### PR TITLE
chore: pin GitHub Actions to SHAs, stop Renovate editing generated files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,21 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "pre-commit": {
+    "enabled": true
+  },
+  "ignorePaths": [
+    "plugins/**"
+  ],
+  "packageRules": [
+    {
+      "description": "Pin GitHub Actions to commit SHAs while keeping readable semver updates",
+      "extends": [
+        "helpers:pinGitHubActionDigests"
+      ],
+      "extractVersion": "^v?(?<version>\\d+\\.\\d+\\.\\d+)$",
+      "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
+    }
   ]
 }


### PR DESCRIPTION
## What

Three Renovate configuration fixes. No workflow files change here — Renovate will raise the actual pinning PR itself once this merges.

### 1. SHA digest pinning

`helpers:pinGitHubActionDigests` pins every action to an immutable commit SHA:

```yaml
- uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
```

The paired `extractVersion` / `versioning` rules make Renovate read that trailing comment as semver, so updates keep arriving as readable "update actions/checkout to v7" PRs instead of opaque digest bumps. Grouping, scheduling, changelogs and automerge behaviour are unaffected.

This closes the gap between what this organisation publishes and what it practises — [action pinning](https://adaptive-enforcement-lab.com/secure/github-actions-security/action-pinning/) is one of the skills shipped from this very repository.

### 2. Stop Renovate editing generated content

`ignorePaths: ["plugins/**"]`.

Renovate has been raising PRs against generated Dockerfiles, for example `renovate/alpine-3.x`, which touches four files under `plugins/`. `CONTRIBUTING.md` states that directory must never be hand-edited, and the next `skillgen` run reverts any change made there.

Those dependencies live in the source documentation and reach this repository through regeneration. The alpine bump is being made there instead.

### 3. Enable the pre-commit manager

`config:recommended` leaves Renovate's `pre-commit` manager disabled, which is how hook revisions drift out of step with the actions that mirror them. Enabling it keeps them aligned.

## Verification

```
renovate-config-validator renovate.json
 INFO: Validating renovate.json
 INFO: Config validated successfully
```

## Expected follow-up

Once merged, Renovate opens a pinning PR converting all tag references to SHAs. That diff is large but mechanical, and reviewing it separately from a behavioural change is deliberate.

## Checklist

- [x] Conventional commit message
- [x] Branch named `chore/description`
- [x] Config validated with the official validator
- [x] No manual edits to generated `plugins/` content