### PR TITLE
docs: refresh README and consolidate renovate action updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
           fi
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
         with:
           name: generator-binaries-${{ github.run_number }}
           path: bin/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # 7.0.0
         with:
           go-version: '1.26'
           cache-dependency-path: skillgen/go.sum

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # 5.6.0
         with:
           go-version: '1.26'
           cache-dependency-path: skillgen/go.sum

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
           fi
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
         with:
           name: generator-binaries-${{ github.run_number }}
           path: bin/*

--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Generate token
         id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # 2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # 3.2.0
         with:
           app-id: ${{ secrets.CORE_APP_ID }}
           private-key: ${{ secrets.CORE_APP_PRIVATE_KEY }}

--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -41,7 +41,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # 7.0.0
         with:
           go-version: '1.26'
           cache-dependency-path: skillgen/go.sum

--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -41,7 +41,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # 5.6.0
         with:
           go-version: '1.26'
           cache-dependency-path: skillgen/go.sum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       # This ensures release-please can create PRs and releases with proper permissions
       - name: Generate AEL CORE App Token
         id: app_token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # 2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # 3.2.0
         with:
           app-id: ${{ secrets.CORE_APP_ID }}
           private-key: ${{ secrets.CORE_APP_PRIVATE_KEY }}
@@ -82,7 +82,7 @@ jobs:
       # This ensures the Build Workflow is triggered when Release Workflow completes
       - name: Generate AEL CORE App Token
         id: generate_token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # 2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # 3.2.0
         with:
           app-id: ${{ secrets.CORE_APP_ID }}
           private-key: ${{ secrets.CORE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # 5.0.0
         with:
           token: ${{ steps.app_token.outputs.token }}
           config-file: release-please-config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # 4.4.1
         with:
           token: ${{ steps.app_token.outputs.token }}
           config-file: release-please-config.json

--- a/README.md
+++ b/README.md
@@ -149,10 +149,11 @@ cd skillgen && go test ./...
   --source ../adaptive-enforcement-lab-com/docs \
   --output plugins \
   --plugin-metadata ./plugin-metadata.json \
-  --release-manifest ./.release-please-manifest.json
+  --release-manifest ./.release-please-manifest.json \
+  --templates skillgen/templates
 ```
 
-Add `--verbose` for per-document logging. See [CLAUDE.md](CLAUDE.md) for the full flag reference and [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
+`--templates` is required in practice: the flag defaults to `./templates`, which does not exist at the repo root, so omitting it fails with `pattern matches no files`. Add `--verbose` for per-document logging. See [CLAUDE.md](CLAUDE.md) for the full flag reference and [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Claude Code skills marketplace for secure development patterns, enforcement automation, and build engineering.
 
-**Status**: 🚧 Under active development
+**118 skills** across 4 plugin collections, generated from [AEL documentation](https://adaptive-enforcement-lab.com).
 
 ## Installation
 
@@ -10,46 +10,71 @@ Claude Code skills marketplace for secure development patterns, enforcement auto
 # Add the AEL skills marketplace
 /plugin marketplace add adaptive-enforcement-lab/claude-skills
 
-# Install individual plugin collections
+# Install plugin collections (install any subset)
 /plugin install patterns@ael-skills
-/plugin install enforcement@ael-skills
+/plugin install enforce@ael-skills
+/plugin install secure@ael-skills
 /plugin install build@ael-skills
 ```
 
 ## Available Skills
 
+| Collection | Skills | Version | Focus |
+| ---------- | -----: | ------- | ----- |
+| [`patterns`](plugins/patterns/skills) | 38 | 1.0.2 | Automation and architecture patterns |
+| [`enforce`](plugins/enforce/skills) | 34 | 1.0.2 | Policy-as-code and SDLC hardening |
+| [`secure`](plugins/secure/skills) | 33 | 1.0.2 | Supply chain and platform security |
+| [`build`](plugins/build/skills) | 13 | 1.0.1 | Go CLI and release engineering |
+
 ### Patterns (Development)
-Reusable engineering patterns automatically generated from [AEL documentation](https://adaptive-enforcement-lab.com/patterns/):
 
-- Error handling patterns (fail-fast, circuit breakers, retry logic)
-- State management patterns
-- Performance optimization patterns
-- Resilience and fault tolerance patterns
+From [AEL patterns](https://adaptive-enforcement-lab.com/patterns/):
 
-### Enforcement (Security)
-Security and compliance enforcement automation from [AEL enforcement guides](https://adaptive-enforcement-lab.com/enforce/):
+- GitHub Actions automation — matrix distribution and filtering, work avoidance, idempotency, file distribution
+- Argo Workflows and Argo Events — WorkflowTemplates, event routing, concurrency control, scheduled workflows
+- GitHub App authentication — JWT generation, installation tokens, OAuth user flows, token lifecycle
+- Architecture patterns — hub-and-spoke, strangler fig, separation of concerns, secure-by-design
+- Reliability — fail-fast, graceful degradation, prerequisite checks, chaos engineering for Kubernetes
 
-- Pre-commit hook setup and configuration
-- Policy validation automation
-- Security scanning integration
-- Compliance checking workflows
+### Enforce (Security)
+
+From [AEL enforcement guides](https://adaptive-enforcement-lab.com/enforce/):
+
+- Kyverno policy templates — pod security, image validation, mutation, generation, network, resource governance
+- OPA policy templates — pod security, image security, RBAC, resource governance
+- Repository controls — branch protection enforcement, required status checks
+- Supply chain — SLSA provenance and toolchain integration, policy packaging, multi-source aggregation
+- Operations — phased SDLC hardening roadmap, local development with policy-as-code, incident response playbooks
+
+### Secure (Security)
+
+From [AEL security guides](https://adaptive-enforcement-lab.com/secure/):
+
+- GitHub Actions hardening — action pinning, `GITHUB_TOKEN` permissions, workflow trigger security, third-party action risk
+- Secrets — storing credentials, rotation patterns, secret scanning integration
+- Authentication — OIDC federation, Workload Identity Federation, GitHub core app setup
+- Runners — self-hosted hardening, ephemeral runners, runner group management
+- Platform — GKE hardening (cluster config, network, IAM, runtime), OpenSSF Scorecard, Go security tooling
 
 ### Build (DevOps)
-Build engineering patterns from [AEL build guides](https://adaptive-enforcement-lab.com/build/):
 
-- CI/CD pipeline patterns
-- Release automation strategies
-- Deployment patterns
-- Build optimization techniques
+From [AEL build guides](https://adaptive-enforcement-lab.com/build/):
+
+- Go CLI architecture — framework selection, command architecture, Kubernetes client-go integration
+- Release automation — release-please configuration, modular release pipelines
+- Packaging — distroless container images, static binaries
+- Testing strategies and versioned documentation
+- Open source project templates (CONTRIBUTING, SECURITY, issue forms)
 
 ## Automated Generation
 
-All skills in this repository are automatically generated from AEL documentation:
+All skills in `plugins/` are generated from AEL documentation — **never edit them by hand**:
 
 - **Source**: [adaptive-enforcement-lab.com](https://github.com/adaptive-enforcement-lab/adaptive-enforcement-lab-com)
-- **Generator**: Go-based extraction pipeline
-- **CI/CD**: GitHub Actions workflows
-- **Sync**: Skills update automatically when documentation changes
+- **Generator**: `skillgen`, a Go extraction pipeline in this repo
+- **Sync**: the `generate-skills.yml` workflow runs on `repository_dispatch` (`docs-updated`) from the docs repo, on manual `workflow_dispatch`, and on pull requests to `main`. Dispatch runs open or force-push a PR on the `chore/regenerate-skills` branch; on a release-please PR it commits regenerated output directly to that PR's branch. Regeneration is proposed automatically — merging is a human step.
+
+The same run regenerates `.claude-plugin/marketplace.json` and every `plugins/*/.claude-plugin/plugin.json` from `plugin-metadata.json` plus `.release-please-manifest.json`.
 
 ## Team Distribution
 
@@ -67,7 +92,8 @@ To auto-register this marketplace for your team, add to `.claude/settings.json` 
   },
   "enabledPlugins": {
     "patterns@ael-skills": true,
-    "enforcement@ael-skills": true,
+    "enforce@ael-skills": true,
+    "secure@ael-skills": true,
     "build@ael-skills": true
   }
 }
@@ -77,75 +103,76 @@ To auto-register this marketplace for your team, add to `.claude/settings.json` 
 
 ```
 .claude-plugin/
-└── marketplace.json              # Marketplace catalog
+└── marketplace.json              # Marketplace catalog (GENERATED)
 
 plugins/                          # Generated plugins (DO NOT EDIT)
 ├── patterns/
 │   ├── .claude-plugin/
-│   │   └── plugin.json          # Plugin metadata
-│   └── skills/                   # Pattern skills
+│   │   └── plugin.json           # Plugin metadata (GENERATED)
+│   └── skills/                   # One directory per skill, each with SKILL.md
 ├── enforce/
-│   ├── .claude-plugin/
-│   │   └── plugin.json          # Plugin metadata
-│   └── skills/                   # Enforcement skills
-├── build/
-│   ├── .claude-plugin/
-│   │   └── plugin.json          # Plugin metadata
-│   └── skills/                   # Build skills
-└── secure/
-    ├── .claude-plugin/
-    │   └── plugin.json          # Plugin metadata
-    └── skills/                   # Security skills
+├── secure/
+└── build/
+
+plugin-metadata.json              # Source of truth: descriptions, categories, tags
+.release-please-manifest.json     # Source of truth: versions (release-please owned)
+release-please-config.json        # Multi-component release configuration
 
 skillgen/                         # Generator source
-├── cmd/skillgen/                 # Main application
+├── cmd/skillgen/                 # Entry point and dependency injection
 ├── internal/
-│   ├── domain/                   # Core entities
+│   ├── domain/                   # Core entities (Document, Skill, Marketplace)
 │   ├── ports/                    # Interfaces
-│   ├── adapters/                 # Implementations
-│   └── services/                 # Business logic
-└── templates/                    # Go templates
+│   ├── adapters/                 # filesystem, parser, logger
+│   └── services/                 # extractor, generator, validator
+└── templates/                    # skill, examples, reference, troubleshooting
 
 .github/workflows/
-└── generate-skills.yml           # CI automation
+├── generate-skills.yml           # Regeneration PR automation
+├── build.yml                     # Tests + cross-platform binaries
+└── release.yml                   # release-please
 ```
 
 ## Development
+
+Requires Go 1.26+.
 
 ```bash
 # Build the generator
 cd skillgen && go build -o ../bin/skillgen ./cmd/skillgen
 
-# Run generator (from repo root)
+# Run tests
+cd skillgen && go test ./...
+
+# Run generator (from repo root, needs the docs repo checked out alongside)
 ./bin/skillgen \
   --source ../adaptive-enforcement-lab-com/docs \
   --output plugins \
   --plugin-metadata ./plugin-metadata.json \
   --release-manifest ./.release-please-manifest.json
-
-# Run tests
-cd skillgen && go test ./...
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed development guidelines.
+Add `--verbose` for per-document logging. See [CLAUDE.md](CLAUDE.md) for the full flag reference and [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
 
 ## Architecture
 
-This project follows Clean/Hexagonal Architecture:
+`skillgen` follows Clean/Hexagonal Architecture — dependencies point inward:
 
-- **Domain** (`internal/domain`): Core entities and business logic
-- **Ports** (`internal/ports`): Interfaces for external dependencies
-- **Adapters** (`internal/adapters`): Implementations (filesystem, parsers)
-- **Services** (`internal/services`): Application services (extractors, generators)
-- **CMD** (`cmd/skillgen`): Entry point and dependency injection
+- **Domain** (`skillgen/internal/domain`): core entities, no external dependencies
+- **Ports** (`skillgen/internal/ports`): interfaces for external dependencies
+- **Adapters** (`skillgen/internal/adapters`): filesystem, markdown parser, logger
+- **Services** (`skillgen/internal/services`): extractor, generator, validator
+- **CMD** (`skillgen/cmd/skillgen`): entry point and wiring
+
+Pipeline: read docs → parse frontmatter and sections → extract skills → render templates → write `SKILL.md` (plus optional `examples.md`, `reference.md`, `troubleshooting.md`) → generate marketplace files.
 
 ## Releases
 
-Releases are automated using [release-please](https://github.com/googleapis/release-please):
+Releases are automated with [release-please](https://github.com/googleapis/release-please). Six components version independently, each with its own release PR:
 
-- Conventional commits trigger version bumps
-- Changelog is auto-generated
-- GitHub releases include pre-built binaries for Linux, macOS, and Windows
+`skillgen`, `.claude-plugin`, `plugins/patterns`, `plugins/enforce`, `plugins/secure`, `plugins/build`
+
+Conventional commits drive version bumps and changelog entries. Generator releases publish binaries for Linux, macOS (amd64 and arm64), and Windows.
 
 ## Contributing
 


### PR DESCRIPTION
Two things that were both stale: the README described a marketplace that does not match what the generator produces, and seven Renovate PRs were queued against overlapping action versions.

## README accuracy

The install snippet and the `.claude/settings.json` snippet both named `enforcement@ael-skills`, which does not exist — the plugin is `enforce`. Both also omitted `secure@ael-skills` entirely, so anyone following the README installed three collections, one of which failed.

The skill descriptions were invented rather than observed ("state management patterns", "performance optimization patterns"). Replaced with the collections actually generated today, plus per-collection counts and versions read from `.release-please-manifest.json`:

| Collection | Skills | Version |
| ---------- | -----: | ------- |
| `patterns` | 38 | 1.0.2 |
| `enforce`  | 34 | 1.0.2 |
| `secure`   | 33 | 1.0.2 |
| `build`    | 13 | 1.0.1 |

Also corrected:

- **Broken generator command.** The documented invocation omitted `--templates`, whose default `./templates` does not exist at the repo root — copy-pasting it failed with `pattern matches no files`. Verified the corrected command end to end: 118 skills generated, matching what is committed under `plugins/`.
- **Sync description.** "Skills update automatically when documentation changes" overstated it. Regeneration opens a PR; merging is a human step. Documented all three triggers, including the release-please PR path that commits directly to that PR's branch.
- **Repository structure.** Filled in `plugin-metadata.json`, `.release-please-manifest.json`, `release-please-config.json`, `build.yml`, and `release.yml`, all previously absent, and dropped the invented per-plugin skill topic lists.
- Noted the Go 1.26 toolchain and listed all six independently versioned release-please components.
- Removed the "🚧 Under active development" banner — all four collections are released at 1.0.x.

## Renovate consolidation

All seven open Renovate PRs merged here (#75–#81). Three pairs targeted the same action at different majors; the minor-bump branches only relabelled the version comment on an unchanged SHA, so conflicts were resolved to the higher major:

| Action | Before | After | Supersedes |
| ------ | ------ | ----- | ---------- |
| `actions/create-github-app-token` | 2.2.2 | 3.2.0 | #78 |
| `actions/setup-go` | v5 | 7.0.0 | #79, #75 |
| `actions/upload-artifact` | v4 | 7.0.1 | #80, #76 |
| `googleapis/release-please-action` | v4 | 5.0.0 | #81, #77 |

### Breaking changes reviewed, none applicable

- Every major here is fundamentally a **Node 24 runtime bump**, requiring runner ≥ 2.327.1. All jobs run on `ubuntu-latest` (GitHub-hosted), so this is satisfied.
- `create-github-app-token` v3 removed custom proxy handling and now requires `NODE_USE_ENV_PROXY=1`. No workflow in this repo sets `HTTP_PROXY`/`HTTPS_PROXY`, so nothing to change.
- `setup-go` v6 changed toolchain selection and v7 moved to ESM. Only `go-version` and `cache-dependency-path` are used; both still supported.
- `upload-artifact` v7 adds an optional `archive` input. Only `name`, `path`, and `retention-days` are used.
- `release-please-action` v5 is node24 only. The `<component>--release_created` / `--tag_name` output naming this repo depends on is unchanged.
- **All four pinned SHAs verified against the upstream tags** via the GitHub API — each resolves to exactly the commit claimed in the trailing version comment.

## Verification

- `go mod tidy` — no changes; `go mod verify` — all modules verified
- `gofmt -l .` — clean
- `go build ./cmd/skillgen` — OK
- `go test ./...` — all packages pass
- Workflow YAML parses; `actionlint` reports 21 findings on this branch and **the same 21 on `origin/main`** — all pre-existing, none introduced here

## Known pre-existing issue, not fixed here

`actionlint` flags `github.head_ref` used directly in an inline script in `generate-skills.yml:65` (script injection risk). It predates this branch and is out of scope for a dependency merge — worth a follow-up.