### PR TITLE
chore: correct CLAUDE.md and published plugin descriptions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "build",
       "source": "./plugins/build",
-      "description": "Build engineering patterns for CI/CD pipelines, release automation, and deployment strategies",
+      "description": "Build engineering for Go CLIs and Kubernetes tooling: release-please automation, container packaging, testing strategies, and versioned documentation",
       "version": "1.0.1",
       "category": "devops",
       "author": {
@@ -30,7 +30,7 @@
     {
       "name": "enforce",
       "source": "./plugins/enforce",
-      "description": "Security and compliance enforcement automation including pre-commit hooks, policy checks, and validation",
+      "description": "Policy-as-code enforcement with Kyverno and OPA template libraries, repository controls, SLSA provenance, and phased SDLC hardening",
       "version": "1.0.2",
       "category": "security",
       "author": {
@@ -47,7 +47,7 @@
     {
       "name": "patterns",
       "source": "./plugins/patterns",
-      "description": "Reusable engineering patterns for error handling, state management, performance optimization, and resilience",
+      "description": "Automation and architecture patterns for GitHub Actions, Argo Workflows and Events, GitHub App authentication, idempotency, and resilience",
       "version": "1.0.2",
       "category": "development",
       "author": {
@@ -63,7 +63,7 @@
     {
       "name": "secure",
       "source": "./plugins/secure",
-      "description": "Security patterns and hardening guides for cloud-native applications, GitHub Actions, and supply chain security",
+      "description": "Security hardening for GitHub Actions, secrets and runners, OIDC and Workload Identity Federation, GKE, and supply chain security",
       "version": "1.0.2",
       "category": "security",
       "author": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,8 @@ cd skillgen && go build -o ../bin/skillgen ./cmd/skillgen && cd ..
   --source ../adaptive-enforcement-lab-com/docs \
   --output plugins \
   --plugin-metadata ./plugin-metadata.json \
-  --release-manifest ./.release-please-manifest.json
+  --release-manifest ./.release-please-manifest.json \
+  --templates skillgen/templates
 
 # Run with verbose logging
 ./bin/skillgen \
@@ -29,6 +30,7 @@ cd skillgen && go build -o ../bin/skillgen ./cmd/skillgen && cd ..
   --output plugins \
   --plugin-metadata ./plugin-metadata.json \
   --release-manifest ./.release-please-manifest.json \
+  --templates skillgen/templates \
   --verbose
 
 # Run tests (from skillgen directory)
@@ -44,8 +46,8 @@ gofmt -w skillgen/
 - `--output`: Output path for generated plugins (default: `./plugins`)
 - `--plugin-metadata`: Path to plugin metadata config (default: `./plugin-metadata.json`)
 - `--release-manifest`: Path to release-please manifest (default: `./.release-please-manifest.json`)
-- `--templates`: Path to template directory (default: `./templates`)
-- `--marketplace`: Path to marketplace.json (DEPRECATED - now auto-generated)
+- `--templates`: Path to template directory (default: `./templates`). **Effectively required**: the default does not exist at the repo root, so omitting the flag fails with `pattern matches no files`. Pass `skillgen/templates`.
+- `--marketplace`: Output path for the generated marketplace.json (default: `./.claude-plugin/marketplace.json`). The file's *content* is generated, but this flag still controls where it is written.
 - `--verbose`: Enable verbose logging
 - `--version`: Show version and exit
 
@@ -60,7 +62,9 @@ skillgen/
     domain/            → Core entities (Skill, Document, Marketplace)
     ports/             → Interfaces for external dependencies
     adapters/          → Implementations (filesystem, parser, logger)
-    services/          → Application services (extractor, generator)
+    services/          → Application services (extractor, generator, validator,
+                         marketplace generator)
+  templates/           → Go text/template files
 ```
 
 **Key Principles:**
@@ -103,24 +107,25 @@ skillgen/
 
 The generator processes 4 documentation categories:
 
-- `patterns/` → Development patterns (error handling, state management, etc.)
-- `enforce/` → Security enforcement automation (pre-commit hooks, policy validation)
-- `build/` → Build engineering patterns (CI/CD, release automation)
-- `secure/` → Security patterns and practices
+- `patterns/` → Automation and architecture patterns (GitHub Actions, Argo, GitHub App auth, idempotency)
+- `enforce/` → Policy-as-code enforcement (Kyverno and OPA templates, SLSA, SDLC hardening)
+- `build/` → Build engineering (Go CLIs, release-please, packaging, versioned docs)
+- `secure/` → Security hardening (GitHub Actions, secrets, runners, OIDC, GKE)
+
+The canonical list lives in `skillgen/internal/domain/category.go` (`domain.Categories`). Note the category is `enforce`, not `enforcement`.
 
 Blog posts (detected via frontmatter `date`/`authors` fields) are automatically skipped.
 
 ## Templates
 
-Templates live in `templates/` and use Go's text/template syntax:
+Templates live in `skillgen/templates/` and use Go's text/template syntax. There are four:
 
-- `skill.tmpl` - Base SKILL.md template
-- `pattern_skill.tmpl` - Pattern-specific skills
-- `enforce_skill.tmpl` - Enforcement-specific skills
-- `build_skill.tmpl` - Build-specific skills
+- `skill.tmpl` - SKILL.md template, used for every category
 - `examples.tmpl` - Examples documentation
 - `reference.tmpl` - Reference documentation
 - `troubleshooting.tmpl` - Troubleshooting guides
+
+There are no per-category templates; `skill.tmpl` renders all four collections.
 
 ## Configuration Files
 
@@ -201,7 +206,9 @@ The **SectionMapper** (`internal/services/extractor`) maps source doc sections t
 Source docs use VitePress admonitions (`::: tip`, `::: warning`). The **AdmonitionConverter** transforms these to standard markdown for Claude Code compatibility.
 
 ### Error Handling Philosophy
-The generator logs errors but exits with code 0 even when errors occur. Many errors are expected (missing titles, malformed content) and shouldn't fail CI builds. The generation summary reports error counts for visibility.
+**Per-document** errors are logged but do not change the exit code. Many are expected (missing titles, malformed content) and shouldn't fail CI builds; the generation summary reports error counts for visibility.
+
+**Startup** failures are fatal (`log.Fatal`, exit 1): a missing `--source`, a template directory that loads no `*.tmpl` files, or a failure to walk the source tree. A run that exits 1 with no summary means the generator never got started, not that documents failed.
 
 ## Testing Strategy
 
@@ -213,7 +220,7 @@ The generator logs errors but exits with code 0 even when errors occur. Many err
 
 ## Dependencies
 
-Go 1.25+ with minimal external dependencies:
+Go 1.26+ (`skillgen/go.mod`, matching the version pinned in CI) with minimal external dependencies:
 - `github.com/yuin/goldmark` - Markdown parsing
 - `gopkg.in/yaml.v3` - YAML frontmatter parsing
 
@@ -224,9 +231,10 @@ Go 1.25+ with minimal external dependencies:
 3. **Editing plugins/*/​.claude-plugin/plugin.json directly** - Auto-generated from plugin-metadata.json
 4. **Forgetting --plugin-metadata and --release-manifest flags** - Required for marketplace generation
 5. **Forgetting --source flag** - Generator requires source docs path
-6. **Assuming specific section names** - Source docs vary, extractor uses fuzzy matching
-7. **Breaking template syntax** - Go templates are whitespace-sensitive
-8. **Not testing with actual docs** - Clone AEL docs repo for realistic testing
+6. **Forgetting --templates skillgen/templates** - The default `./templates` does not exist at the repo root, so the run dies before generating anything
+7. **Assuming specific section names** - Source docs vary, extractor uses fuzzy matching
+8. **Breaking template syntax** - Go templates are whitespace-sensitive
+9. **Not testing with actual docs** - Clone AEL docs repo for realistic testing
 
 ## Updating Plugin Metadata
 

--- a/plugin-metadata.json
+++ b/plugin-metadata.json
@@ -20,29 +20,29 @@
   },
   "plugins": {
     "patterns": {
-      "description": "Reusable engineering patterns for error handling, state management, performance optimization, and resilience",
+      "description": "Automation and architecture patterns for GitHub Actions, Argo Workflows and Events, GitHub App authentication, idempotency, and resilience",
       "category": "development",
       "tags": ["patterns", "engineering", "best-practices"],
-      "keywords": ["error-handling", "state-management", "performance", "resilience"]
+      "keywords": ["github-actions", "argo-workflows", "idempotency", "resilience"]
     },
     "enforce": {
       "marketplaceName": "enforce",
-      "description": "Security and compliance enforcement automation including pre-commit hooks, policy checks, and validation",
+      "description": "Policy-as-code enforcement with Kyverno and OPA template libraries, repository controls, SLSA provenance, and phased SDLC hardening",
       "category": "security",
       "tags": ["security", "compliance", "enforcement", "devsecops"],
-      "keywords": ["policy-as-code", "kyverno", "opa"]
+      "keywords": ["policy-as-code", "kyverno", "opa", "slsa"]
     },
     "build": {
-      "description": "Build engineering patterns for CI/CD pipelines, release automation, and deployment strategies",
+      "description": "Build engineering for Go CLIs and Kubernetes tooling: release-please automation, container packaging, testing strategies, and versioned documentation",
       "category": "devops",
       "tags": ["ci-cd", "build", "release", "deployment"],
-      "keywords": ["release-please", "github-actions"]
+      "keywords": ["go-cli", "release-please", "kubernetes", "packaging"]
     },
     "secure": {
-      "description": "Security patterns and hardening guides for cloud-native applications, GitHub Actions, and supply chain security",
+      "description": "Security hardening for GitHub Actions, secrets and runners, OIDC and Workload Identity Federation, GKE, and supply chain security",
       "category": "security",
       "tags": ["security", "hardening", "devsecops", "supply-chain"],
-      "keywords": ["github-actions", "gke", "oidc"]
+      "keywords": ["github-actions", "gke", "oidc", "secrets"]
     }
   }
 }

--- a/plugins/build/.claude-plugin/plugin.json
+++ b/plugins/build/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build",
-  "description": "Build engineering patterns for CI/CD pipelines, release automation, and deployment strategies",
+  "description": "Build engineering for Go CLIs and Kubernetes tooling: release-please automation, container packaging, testing strategies, and versioned documentation",
   "version": "1.0.1",
   "author": {
     "name": "Adaptive Enforcement Lab",
@@ -10,7 +10,9 @@
   "repository": "https://github.com/adaptive-enforcement-lab/claude-skills",
   "license": "MIT",
   "keywords": [
+    "go-cli",
     "release-please",
-    "github-actions"
+    "kubernetes",
+    "packaging"
   ]
 }

--- a/plugins/enforce/.claude-plugin/plugin.json
+++ b/plugins/enforce/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "enforce",
-  "description": "Security and compliance enforcement automation including pre-commit hooks, policy checks, and validation",
+  "description": "Policy-as-code enforcement with Kyverno and OPA template libraries, repository controls, SLSA provenance, and phased SDLC hardening",
   "version": "1.0.2",
   "author": {
     "name": "Adaptive Enforcement Lab",
@@ -12,6 +12,7 @@
   "keywords": [
     "policy-as-code",
     "kyverno",
-    "opa"
+    "opa",
+    "slsa"
   ]
 }

--- a/plugins/patterns/.claude-plugin/plugin.json
+++ b/plugins/patterns/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "patterns",
-  "description": "Reusable engineering patterns for error handling, state management, performance optimization, and resilience",
+  "description": "Automation and architecture patterns for GitHub Actions, Argo Workflows and Events, GitHub App authentication, idempotency, and resilience",
   "version": "1.0.2",
   "author": {
     "name": "Adaptive Enforcement Lab",
@@ -10,9 +10,9 @@
   "repository": "https://github.com/adaptive-enforcement-lab/claude-skills",
   "license": "MIT",
   "keywords": [
-    "error-handling",
-    "state-management",
-    "performance",
+    "github-actions",
+    "argo-workflows",
+    "idempotency",
     "resilience"
   ]
 }

--- a/plugins/secure/.claude-plugin/plugin.json
+++ b/plugins/secure/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "secure",
-  "description": "Security patterns and hardening guides for cloud-native applications, GitHub Actions, and supply chain security",
+  "description": "Security hardening for GitHub Actions, secrets and runners, OIDC and Workload Identity Federation, GKE, and supply chain security",
   "version": "1.0.2",
   "author": {
     "name": "Adaptive Enforcement Lab",
@@ -12,6 +12,7 @@
   "keywords": [
     "github-actions",
     "gke",
-    "oidc"
+    "oidc",
+    "secrets"
   ]
 }

--- a/skillgen/internal/domain/marketplace.go
+++ b/skillgen/internal/domain/marketplace.go
@@ -23,7 +23,7 @@ type MarketplaceMetadata struct {
 }
 
 // Plugin represents a skill collection within the marketplace.
-// Each plugin corresponds to a category: patterns, enforcement, build, secure.
+// Each plugin corresponds to a category: patterns, enforce, build, secure.
 type Plugin struct {
 	Name        string        `json:"name"`
 	Source      string        `json:"source"`

--- a/skillgen/internal/domain/skill.go
+++ b/skillgen/internal/domain/skill.go
@@ -16,7 +16,7 @@ type SkillMetadata struct {
 	Name                string // Kebab-case name derived from title
 	Title               string // Display title from frontmatter
 	Description         string // From frontmatter
-	Category            string // patterns, enforcement, build, secure
+	Category            string // patterns, enforce, build, secure
 	Tags                []string
 	WhenToUse           string      // Extracted from "Why It Matters" or similar sections
 	Prerequisites       string      // Extracted from "Prerequisites" section


### PR DESCRIPTION
Follow-up to #82, covering the two defects flagged there. Everything below was verified against the code, not the prose.

## Published plugin descriptions were wrong

`plugin-metadata.json` is the source of truth for what users read in the marketplace listing, and three of four entries advertised skills that do not exist:

| Collection | Advertised | Reality |
| ---------- | ---------- | ------- |
| `patterns` | "state management, performance optimization" | No such skills. Actual: GitHub Actions automation, Argo Workflows/Events, GitHub App auth, idempotency, resilience |
| `enforce` | "pre-commit hooks" | No pre-commit skill. Actual: Kyverno + OPA template libraries, repository controls, SLSA, SDLC hardening |
| `build` | "deployment strategies" | No deployment skill. Actual: Go CLI architecture, release-please, packaging, testing, versioned docs |
| `secure` | broadly accurate | Refined to name secrets and runners, which are a large share of the 33 skills |

Keywords updated to match. Regenerated `.claude-plugin/marketplace.json` and the four `plugin.json` files through `skillgen` as designed — not hand-edited.

**The regeneration touched only those five metadata files.** That is itself a useful signal: `plugins/` is currently in sync with the docs repo, no drift. A second run produced no further changes, so the output is stable.

## CLAUDE.md claims that did not match the code

- **The generator invocation was broken in both examples** — same `--templates` defect as the README in #82. Default `./templates` does not exist at the repo root, so the documented command dies before generating anything. Added the flag plus a pitfall entry.
- **`--marketplace` was labelled `DEPRECATED - now auto-generated`.** It is not deprecated: `main.go:173` still passes it to `MarketplaceGenerator.Generate` as the output path. The content is generated; the destination is still this flag's job.
- **Three of seven listed templates do not exist** — `pattern_skill.tmpl`, `enforce_skill.tmpl`, `build_skill.tmpl`. There are four templates and `skill.tmpl` renders every category. Also corrected the location to `skillgen/templates/`.
- **Go version** claimed 1.25+; `go.mod` and CI both pin 1.26.
- **Architecture tree** omitted the `validator` and marketplace-generator services.
- **"Exits with code 0 even when errors occur"** was only half true. Correct for per-document errors; a missing `--source`, a template dir matching no `*.tmpl`, or a source-walk failure are all `log.Fatal` (exit 1). Split the two cases, since the difference is exactly what you need when a CI run fails silently.
- Category descriptions rewritten to match reality, now citing `domain.Categories` as canonical.

Also fixed two stale comments in `skillgen/internal/domain` that named the category `enforcement`. `domain.Categories` has always said `enforce`.

## Deliberately titled `chore:`

Each `plugins/*` directory is its own release-please package with `separate-pull-requests: true`, and squash merge means this PR's title becomes the release-please commit. A `fix:` title here would open **five** release PRs (four collections plus marketplace) for a description correction. `chore:` lands the fix with no version bump. Say the word if you'd rather publish it as a versioned patch and I will retitle.

## Verification

- `gofmt -l` clean, `go build` OK, `go test ./...` all packages pass
- Generator run: 118 skills processed, 0 errors, 0 invalid, 0 warnings
- Idempotency confirmed: second run produced no diff

## Still outstanding, not in this PR

- `github.head_ref` used directly in an inline script in `generate-skills.yml:65` (script injection risk, flagged by actionlint, predates both PRs)
- `skillgen/internal/services/skills/` accumulates empty output directories from test runs writing into the source tree — untracked, so harmless, but the tests should use `t.TempDir()`