### PR TITLE
fix: pass branch name through env to close script injection in generate-skills.yml

### DIFF
--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -62,6 +62,11 @@ jobs:
       - name: Create pull request or commit to existing PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Pass context through the environment rather than interpolating it
+          # into the script. A branch name is attacker-controlled text, and
+          # ${{ }} substitution happens before the shell parses the script.
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           # Configure git
           git config user.name "github-actions[bot]"
@@ -79,9 +84,9 @@ jobs:
           fi
 
           # Determine target branch based on event type
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
             # Triggered by release-please PR - commit directly to that branch
-            BRANCH="${{ github.head_ref }}"
+            BRANCH="$HEAD_REF"
             echo "Committing to existing release-please PR branch: $BRANCH"
 
             SKILL_COUNT=$(find plugins/ -name "SKILL.md" | wc -l | xargs)


### PR DESCRIPTION
Closes the `actionlint` finding flagged in #82 and #83 but deferred as out of scope for those PRs.

## The defect

`generate-skills.yml` interpolated `${{ github.head_ref }}` straight into a `run` block:

```yaml
BRANCH="${{ github.head_ref }}"
```

GitHub substitutes `${{ }}` **before** the shell parses the script, so the branch name is not data — it is executable text. A ref containing shell metacharacters runs as commands on the runner, in a step whose environment holds the CORE app installation token.

The job-level guard limits `pull_request` runs to refs starting with `release-please--`, which narrows the window but does not close it: `startsWith` is a prefix test, not a character allowlist, so `release-please--x"; <command>; #` satisfies it.

## The fix

Pass the context through the environment and quote it at the point of use, so the value is only ever data:

```yaml
env:
  EVENT_NAME: ${{ github.event_name }}
  HEAD_REF: ${{ github.head_ref }}
run: |
  if [ "$EVENT_NAME" = "pull_request" ]; then
    BRANCH="$HEAD_REF"
```

## Deliberately left alone

Three other `github.head_ref` / `github.event_name` references are not shell-injectable and are unchanged:

- `if:` at lines 15-16 — expression context, never reaches a shell
- `ref:` at line 34 — an action input, consumed as a value by `actions/checkout`
- `Trigger:` at line 157 — inside a `<<'EOF'` heredoc, and `github.event_name` is a fixed enum, not attacker-controlled. Converting it would mean unquoting the heredoc delimiter, which would start expanding `$` and backticks in the PR body — a net loss.

## Verification

- `actionlint`: **21 findings on `main` → 20 on this branch.** The injection finding is gone; the remaining 20 are the pre-existing SC2086 set in `build.yml`, untouched.
- Workflow YAML parses; every `run` block passes `bash -n`.

**Runtime caveat, stated plainly:** this PR cannot exercise the changed code path itself. The `generate` job only runs on `pull_request` when the head ref starts with `release-please--`, so it will be skipped here. I validated it by `workflow_dispatch` against this branch instead — see the comment below.