### PR TITLE
docs: correct the versioning rules in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,17 +175,30 @@ Release-please manages 6 independent components:
 
 Each uses separate-pull-requests for independent versioning.
 
+**A commit bumps only the components whose paths it touches.** This is the single most surprising part of the setup: one commit spanning several component directories opens one release PR *per component*. A `chore:` commit that edited `.claude-plugin/marketplace.json`, all four `plugins/*/.claude-plugin/plugin.json`, and two files under `skillgen/` opened **six** release PRs at once (#84-#89), one per package.
+
+`always-update: true` keeps existing release PRs refreshed as `main` moves. It does not create a release PR on its own — a `docs:`-titled commit produced none.
+
+**Merge release PRs one at a time.** All of them modify `.release-please-manifest.json`, so merging one leaves the rest out of date. Let the Release run finish before merging the next; release-please updates the remaining PRs, and `generate-skills.yml` re-syncs their `marketplace.json`. Merge the four collections first, then `marketplace` (its `marketplace.json` aggregates the collection versions), then `skillgen` last, since its release dispatches the binary build.
+
 ## Conventional Commits
 
-Use these commit prefixes for release-please automation:
+Use these commit prefixes for release-please automation. The behaviour below comes from `changelog-sections` in `release-please-config.json` — a type listed as visible there is releasable, and a type marked `hidden: true` is not:
 
-- `feat:` → Minor version bump, new features
-- `fix:` → Patch version bump, bug fixes
-- `chore:` → Maintenance, no version bump
-- `docs:` → Documentation only, hidden from changelog
-- `refactor:` → Code refactoring, appears in changelog
-- `test:` → Test changes, hidden from changelog
-- `perf:` → Performance improvements, appears in changelog
+| Prefix | Bump | Changelog section |
+| ------ | ---- | ----------------- |
+| `feat:` | minor | Features |
+| `fix:` | patch | Bug Fixes |
+| `perf:` | patch | Performance |
+| `refactor:` | patch | Code Refactoring |
+| `chore:` | **patch** | Maintenance |
+| `docs:` | none | hidden |
+| `test:` | none | hidden |
+| `ci:` | none | hidden |
+
+**`chore:` bumps the version in this repo.** It is configured as a visible "Maintenance" section, so it is releasable — unlike the release-please default, where `chore` is inert. Use `docs:`, `test:` or `ci:` when you want a change to land without cutting a release.
+
+**Squash merge means the PR title is the commit release-please parses.** The repo allows squash merge only, so the individual commits on a branch are discarded and the PR title becomes the conventional commit. A branch of tidy `fix:` commits merged under a `chore:` title releases as a patch chore; the reverse is also true. Title the PR as the release you intend.
 
 ## Key Implementation Notes
 


### PR DESCRIPTION
Fixes the last defect flagged in #83 — and it is one I got wrong myself while merging that PR, so the correction is written from what actually happened rather than from the config alone.

## The false claim

`CLAUDE.md` said:

> `chore:` → Maintenance, no version bump

That is release-please's *default* behaviour, not this repo's. `release-please-config.json` lists `chore` as a visible `Maintenance` section in `changelog-sections`, which makes it releasable. The proof is #83: a single `chore:`-titled commit cut patch releases across **six** components (#84-#89 → patterns/enforce/secure 1.0.3, build 1.0.2, marketplace 1.0.2, skillgen 1.0.3).

I titled #83 `chore:` specifically to avoid version bumps, citing this line. It bumped everything.

## What replaced it

A table derived from `changelog-sections` rather than from memory:

| Prefix | Bump | Section |
| ------ | ---- | ------- |
| `feat:` | minor | Features |
| `fix:` | patch | Bug Fixes |
| `perf:` | patch | Performance |
| `refactor:` | patch | Code Refactoring |
| `chore:` | **patch** | Maintenance |
| `docs:` / `test:` / `ci:` | none | hidden |

Plus three mechanics that are easy to get wrong and cost real time:

1. **A commit bumps only the components whose paths it touches.** #83 edited `.claude-plugin/marketplace.json`, four `plugin.json` files, and two files under `skillgen/` — six packages, hence six release PRs. Nothing forced them; the commit simply reached every component.
2. **`always-update: true` refreshes existing release PRs, it does not create them.** Evidence: #82 was titled `docs:` and produced no release PR at all. My first explanation for the six PRs blamed `always-update`; that was wrong, and the file now records the correct mechanic.
3. **Squash merge makes the PR title the commit release-please parses.** Squash is the only merge method enabled, so branch commits are discarded. A branch of `fix:` commits merged under a `chore:` title releases as a chore.

Also added the release-PR merge order, since all of them touch `.release-please-manifest.json` and invalidate one another: four collections → `marketplace` → `skillgen` last, one at a time, letting each Release run finish.

## Release impact of this PR: none

`CLAUDE.md` sits at the repo root, which belongs to no release-please package (`skillgen`, `.claude-plugin`, `plugins/*`). Verified the diff touches zero component paths, and the `docs:` title is hidden regardless — so this cuts no release, by both mechanisms.